### PR TITLE
Update command line `emulator` path

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
             "properties": {
                 "androidEmulatorLauncher.emulatorPath": {
                     "type": "string",
-                    "default": "~/Library/Android/sdk/tools/emulator",
+                    "default": "~/Library/Android/sdk/emulator/emulator",
                     "description": "absolute path of the `emulator` tool",
                     "scope": "application"
                 },


### PR DESCRIPTION
The Emulator tool is now separate from the general Android SDK tools (https://developer.android.com/studio/releases/emulator). It looks like there is no longer `"~/Library/Android/sdk/tools/emulator"`. Now it is `"~/Library/Android/sdk/emulator/emulator"`.